### PR TITLE
Support CORS and make header matching more permissive

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ curl localhost:3000/api/simple-schema -H 'content-type: application/json' -d '{"
 ### Options
 - mock
   - --port, -p - port for running mock server, defaults to 3000 (optional)
+  - --no-cors, -C - disable CORS support (optional)
   - --watch, -w - to watch current directory for contract changes (optional)
   - --tls, -t - enable [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)  with a self signed certificate ( setting `NODE_TLS_REJECT_UNAUTHORIZED=0` when consuming from node might be required )
 - verify

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ program
   .option('-p, --port <port>', 'Port for running mock server. Defaults to 3000.')
   .option('-w, --watch', 'Watch for changes.')
   .option('-t, --tls', 'Use TLS. Defaults to false.')
+  .option('-C, --no-cors', 'Disable CORS support.')
   .description('Provide mock responses for matching consumer requests.')
   .action((contract = './contracts', options) => {
     mockServer(contract, options)

--- a/mock.js
+++ b/mock.js
@@ -24,7 +24,12 @@ const ignoredHeaders = [
 
 const hasPath = R.pathEq([ 'request', 'path' ])
 const hasMethod = R.pathEq([ 'request', 'method' ])
-const hasHeaders = R.pathEq([ 'request', 'headers' ])
+
+const hasHeaders = headers => R.pipe(
+  R.path(['request', 'headers']),
+  R.merge(headers),
+  R.equals(headers)
+)
 
 const hasCorrectSchema = ({ method, payload }) => contract => {
   const { bodySchema } = contract.request
@@ -74,9 +79,9 @@ const tlsOpts = () => ({
   cert: fs.readFileSync(path.join(__dirname, 'certs/cert.pem'))
 })
 
-const createServerFor = (contracts, { port = 3000, tls = false } = {}) => {
+const createServerFor = (contracts, { port = 3000, tls = false, cors = true } = {}) => {
   const server = new hapi.Server()
-  server.connection(Object.assign({ port }, tls ? { tls: tlsOpts() } : {}))
+  server.connection(Object.assign({ port, routes: { cors: cors } }, tls ? { tls: tlsOpts() } : {}))
   server.route({
     method: allMethods,
     path: '/{path*}',

--- a/mock.spec.js
+++ b/mock.spec.js
@@ -59,6 +59,25 @@ test.cb('returns response for a matching POST schema', t => {
   })
 })
 
+test.cb('returns response for a matching schema with additional headers', t => {
+  const server = serveContract('simple-schema')
+  const payload = { hello: 'world' }
+  const headers = {
+    'content-type': 'application/json',
+    'postman-token': '2dlnf3qur0w3fiojclksmx02u9prqo'
+  }
+
+  return server.inject({
+    url: '/api/simple-schema',
+    method: 'POST',
+    headers,
+    payload
+  }, res => {
+    t.is(res.statusCode, 200)
+    t.end()
+  })
+})
+
 test('supports https mocks', t => {
   const server = serveContract('simple', { tls: true })
   t.is(server.info.protocol, 'https')


### PR DESCRIPTION
My usage of curried functions may not be the best, please do let me know if there's something that could be simplified. :)

## Change 1: CORS
As CORS is usually necessary when testing mock apis in a browser application, adding support to it by default, with a `--no-cors` option to disable.

## Change 2: Header matching
In the current implementation of the mock api, the headers specified in the contract must match exactly the ones sent in the request.
When using a browser or a tool like Postman, some extra headers will be added which we don't have control over, so the request will not match the contract.
Additionally, it will be useful to write contracts accounting only for specific headers.
This update changes the comparison to only account for the headers specified in the contract.

### Example of a match in the new implementation
#### Contract
```
{
    'content-type': 'application/json'
}
```

#### Request
```
    'content-type': 'application/json',
    'postman-token': '092u3rijwofesdo2ur3p9iqf'
```